### PR TITLE
Workflow update

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -32,6 +32,8 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     needs: testJob
+    if: github.event_name == 'push'  # Runs only on push to master
+
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
push-deploy will only happen on push to master, not on every pull-request we create possibly overwriting our azure-cloud production